### PR TITLE
Fix: Use correct 'DbId' parameter casing

### DIFF
--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -17,19 +17,19 @@ Before starting, open your web browser's developer tools (usually by pressing F1
 
 1.  **URL Construction**:
     *   Open the `provided_index.html` file in your web browser.
-    *   Modify the URL in the browser's address bar by appending a valid `Dbid`. For example, if `123` is a valid ID, the URL should look like:
-        `file:///path/to/your/provided_index.html?Dbid=123`
+    *   Modify the URL in the browser's address bar by appending a valid `DbId`. For example, if `123` is a valid ID, the URL should look like:
+        `file:///path/to/your/provided_index.html?DbId=123`
         (Replace `file:///path/to/your/` with the actual path to the file, or if hosted on a server, use the appropriate http/https URL).
     *   Press Enter to load the page with the new URL.
 
 2.  **Expected Results**:
     *   **Displayed Text**:
-        *   Verify that the text "Verkooprelatie: 123" (or "Verkooprelatie: [YourDbidValue]") is displayed prominently on the page (within the `<p id="dbidDisplay">` element).
+    *   Verify that the text "Verkooprelatie: 123" (or "Verkooprelatie: [YourDbIdValue]") is displayed prominently on the page (within the `<p id="dbidDisplay">` element).
     *   **Power BI Iframe**:
         *   Verify that an iframe element is visible on the page.
         *   The iframe should attempt to load the Power BI report.
-            *   If you are using the placeholder `reportId` or if `123` is not a valid `Dbid` in your Power BI dataset for the specified report, the iframe might show an error from Power BI (e.g., "Report not found" or "Can't display this visual"). This is acceptable for this test as long as the iframe *attempts* to load using the constructed URL.
-            *   If you have configured a valid `reportId`, `ctid`, and are using a `Dbid` that exists in your dataset, you should see the report filtered for that `Dbid`.
+            *   If you are using the placeholder `reportId` or if `123` is not a valid `DbId` in your Power BI dataset for the specified report, the iframe might show an error from Power BI (e.g., "Report not found" or "Can't display this visual"). This is acceptable for this test as long as the iframe *attempts* to load using the constructed URL.
+            *   If you have configured a valid `reportId`, `ctid`, and are using a `DbId` that exists in your dataset, you should see the report filtered for that `DbId`.
     *   **Console Errors**:
         *   Check the browser's JavaScript console. There should be no JavaScript errors reported from the page's scripts.
 
@@ -47,9 +47,9 @@ Before starting, open your web browser's developer tools (usually by pressing F1
     *   **Console Errors**:
         *   No JavaScript errors in the console.
 
-3.  **URL Construction (Option B - Empty Dbid parameter)**:
-    *   Modify the URL to have an empty `Dbid` parameter:
-        `file:///path/to/your/provided_index.html?Dbid=`
+3.  **URL Construction (Option B - Empty DbId parameter)**:
+    *   Modify the URL to have an empty `DbId` parameter:
+        `file:///path/to/your/provided_index.html?DbId=`
     *   Press Enter to load the page.
 
 4.  **Expected Results (Option B)**:
@@ -63,8 +63,8 @@ Before starting, open your web browser's developer tools (usually by pressing F1
 **Test Scenario 3: `Dbid` with a Single Quote**
 
 1.  **URL Construction**:
-    *   Modify the URL to include a `Dbid` with a single quote:
-        `file:///path/to/your/provided_index.html?Dbid=test'quote`
+    *   Modify the URL to include a `DbId` with a single quote:
+        `file:///path/to/your/provided_index.html?DbId=test'quote`
     *   Press Enter to load the page.
 
 2.  **Expected Results**:
@@ -76,13 +76,13 @@ Before starting, open your web browser's developer tools (usually by pressing F1
         *   **Method 1: Inspecting `URLCompleet` (Easier)**
             *   Go to the "Console" tab in your browser's developer tools.
             *   Type `URLCompleet` and press Enter.
-            *   The console should display the constructed Power BI URL. Verify that the `Dbid` part in the filter query looks like `...Debiteurnummer%20eq%20%27test%27%27quote%27`. Note the `test%27%27quote` part, where `%27` is the URL encoding for a single quote, and `''` (two single quotes) is the escaped form within the OData string. The important part is seeing `test''quote` (after URL decoding the `%27`s that surround the value) as the value being compared.
+            *   The console should display the constructed Power BI URL. Verify that the `DbId` part in the filter query looks like `...Debiteurnummer%20eq%20%27test%27%27quote%27`. Note the `test%27%27quote` part, where `%27` is the URL encoding for a single quote, and `''` (two single quotes) is the escaped form within the OData string. The important part is seeing `test''quote` (after URL decoding the `%27`s that surround the value) as the value being compared.
         *   **Method 2: Network Inspector (More Thorough)**
             *   Go to the "Network" tab in your browser's developer tools.
-            *   Reload the page (`file:///path/to/your/provided_index.html?Dbid=test'quote`).
+            *   Reload the page (`file:///path/to/your/provided_index.html?DbId=test'quote`).
             *   Look for a request initiated by the iframe. The name might contain `reportEmbed` or your `reportId`.
             *   Select this request and examine the full URL.
-            *   Verify the `filter` parameter in the URL. It should show the `Dbid` with the single quote escaped as two single quotes, and then URL encoded. For example, you should see something like: `...&filter=Verkooprelatie%2FDebiteurnummer%20eq%20%27test%27%27quote%27&...`
+            *   Verify the `filter` parameter in the URL. It should show the `DbId` with the single quote escaped as two single quotes, and then URL encoded. For example, you should see something like: `...&filter=Verkooprelatie%2FDebiteurnummer%20eq%20%27test%27%27quote%27&...`
                 *   Decoded, `Verkooprelatie%2FDebiteurnummer` is `Verkooprelatie/Debiteurnummer`.
                 *   Decoded, `%20eq%20%27` is ` eq '`.
                 *   Decoded, `test%27%27quote` is `test''quote`.

--- a/provided_index.html
+++ b/provided_index.html
@@ -10,9 +10,9 @@
 // Variable to store the complete Power BI URL
 let URLCompleet;
 
-// Get the 'Dbid' parameter from the current URL's query string
+// Get the 'DbId' parameter from the current URL's query string
 const urlParams = new URLSearchParams(window.location.search);
-const myParam = urlParams.get('Dbid'); // 'Dbid' is the customer identifier
+const myParam = urlParams.get('DbId'); // 'DbId' is the customer identifier
 
 // Get a reference to the HTML element used to display messages
 const displayElement = document.getElementById('dbidDisplay');


### PR DESCRIPTION
Updates the JavaScript to correctly read the 'DbId' URL parameter, addressing a case sensitivity issue where 'Dbid' was previously used. The Power BI report was failing to filter as the parameter was not found.

- Changed `urlParams.get('Dbid')` to `urlParams.get('DbId')`.
- Updated `MANUAL_TESTING.md` to reflect the correct `DbId` casing in test URLs and instructions.